### PR TITLE
Update action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -9,3 +9,6 @@ inputs:
 runs:
   using: "docker"
   image: "Dockerfile"
+branding: 
+  icon: "arrow-up"
+  color: "blue"


### PR DESCRIPTION
This pull request introduces a small update to the `action.yaml` file by adding branding information for the GitHub Action.

* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR12-R14): Added `branding` with `icon` set to "arrow-up" and `color` set to "blue" to enhance the appearance of the action in the GitHub Actions marketplace.